### PR TITLE
Fix wrong md5 algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ MigrationChangeChecker.setup()
 ``` 
 
 With the optional `.withHashAlgorithm(...)` the used hash mechanism can be set.
-MMC only supports `MD5` and `SHA-2` right now.
-If none is set, `SHA-2` is used.
+MMC supports `MD5`,`SHA-256` and `SHA-512` right now.
+If none is set, `SHA-256` is used.
 
 The ``.withHashPair(<filename>, <hash>)`` adds a new hash to the internal collection.
 To calculate the hash use a tool of your liking or extract the hash from the log of a failed verification.

--- a/src/main/java/de/pixel/mcc/HashAlgorithm.java
+++ b/src/main/java/de/pixel/mcc/HashAlgorithm.java
@@ -1,4 +1,4 @@
-package de.pixel.mcc.internal;
+package de.pixel.mcc;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -10,7 +10,7 @@ public enum HashAlgorithm {
     MD5 {
         @Override
         public String getHexHash(final InputStream input) throws IOException {
-            return DigestUtils.md2Hex(input);
+            return DigestUtils.md5Hex(input);
         }
 
         @Override

--- a/src/main/java/de/pixel/mcc/MigrationChangeChecker.java
+++ b/src/main/java/de/pixel/mcc/MigrationChangeChecker.java
@@ -1,6 +1,5 @@
 package de.pixel.mcc;
 
-import de.pixel.mcc.internal.HashAlgorithm;
 import de.pixel.mcc.internal.VerifyException;
 
 import java.io.IOException;

--- a/src/test/java/de/pixel/mcc/ExampleTest.java
+++ b/src/test/java/de/pixel/mcc/ExampleTest.java
@@ -1,6 +1,5 @@
 package de.pixel.mcc;
 
-import de.pixel.mcc.internal.HashAlgorithm;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/de/pixel/mcc/HashAlgorithmTest.java
+++ b/src/test/java/de/pixel/mcc/HashAlgorithmTest.java
@@ -1,4 +1,4 @@
-package de.pixel.mcc.internal;
+package de.pixel.mcc;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,7 +42,7 @@ public class HashAlgorithmTest {
 
     private static Stream<Arguments> hashDataProvider() {
         return Stream.of(
-                Arguments.of(HashAlgorithm.MD5, "dd34716876364a02d0195e2fb9ae2d1b"),
+                Arguments.of(HashAlgorithm.MD5, "098f6bcd4621d373cade4e832627b4f6"),
                 Arguments.of(HashAlgorithm.SHA2_256, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"),
                 Arguments.of(HashAlgorithm.SHA2_512, "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67" +
                         "b143732c304cc5fa9ad8e6f57f50028a8ff")

--- a/src/test/java/de/pixel/mcc/MigrationChangeCheckerTest.java
+++ b/src/test/java/de/pixel/mcc/MigrationChangeCheckerTest.java
@@ -1,6 +1,5 @@
 package de.pixel.mcc;
 
-import de.pixel.mcc.internal.HashAlgorithm;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 


### PR DESCRIPTION
Accidentally the `MD2` was used instead of the `MD5` algorithm.
This PR corrects it.

It also list the available mechanisms in more detail.